### PR TITLE
Bugfix for -NotLike operator conversion from Filter to Criteria 

### DIFF
--- a/SMLets.Shared/Code/EntityObjects.cs
+++ b/SMLets.Shared/Code/EntityObjects.cs
@@ -221,7 +221,7 @@ public class ObjectCmdletHelper : SMCmdletBase
             OpToOp.Add("-le","<=");
             OpToOp.Add("-ge",">=");
             OpToOp.Add("-like","like");
-            OpToOp.Add("-notlike","! like");
+            OpToOp.Add("-notlike","not like");
             OpToOp.Add("-isnull", "is null");
             OpToOp.Add("-isnotnull", "is not null");
             re = new Regex("\\*");

--- a/SMLets.Shared/Test/test-getonotlike.ps1
+++ b/SMLets.Shared/Test/test-getonotlike.ps1
@@ -1,0 +1,6 @@
+$VerboseResult = (Get-SCSMObject -Class (Get-SCSMClass System.Workitem.Incident$) -Filter "Description -NotLike 'Lorem ipsum dolor*'" -Verbose) 4>&1
+foreach ($Row in $VerboseResult)
+{
+    if($Row -like '*!*'){"FAIL";Break}
+}
+"PASS"


### PR DESCRIPTION
Here's an example of how the operators -Like and -NotLike are currently handled when converted from a Filter to a Criteria:

-Like
<img width="603" alt="Screenshot 2025-02-21 133045" src="https://github.com/user-attachments/assets/36ac04f4-23d3-4a3d-88d6-09120838d9ec" />

-NotLike
<img width="623" alt="Screenshot 2025-02-21 133147" src="https://github.com/user-attachments/assets/fe107188-d056-4081-98d8-fbf2171cc8e0" />

As we can see "-NotLike" results in "! Like" which is then interpreted as "Like" in the creation of the xml Criteria.

-Like
<img width="749" alt="Screenshot 2025-02-21 133307" src="https://github.com/user-attachments/assets/3772ff25-1b02-4cdc-8614-871db65b6144" />

-NotLike /  "! Like"
<img width="749" alt="Screenshot 2025-02-21 133344" src="https://github.com/user-attachments/assets/261b1dac-29b8-4083-83d4-bcb4b1a3a0da" />

With the adjustments in EntityObjects.cs to change the "!" to "not" the operator matching. The Criteria is created with the corrector operator in the XML. 
![After_Screenshot 2025-02-21 134129](https://github.com/user-attachments/assets/a07b4fb8-d3ab-4f2d-a429-4c6fe3cb14ea)

Resulting in a expected result when using -NotLike in the filter.
-Like (after changes)
<img width="564" alt="after_Screenshot 2025-02-21 133936" src="https://github.com/user-attachments/assets/e8fc7a56-1724-4623-9deb-a73fd59749ac" />

-NotLike (after changes)
<img width="589" alt="After_Screenshot 2025-02-21 134038" src="https://github.com/user-attachments/assets/9c9c6568-4293-44d0-924d-289f45891b86" />
